### PR TITLE
Adds feature to allow passing attributes through to derived types (also updates dependencies and unifies workspace versioning)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bit-set"
@@ -137,15 +137,15 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.159"
+version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
 name = "libm"
-version = "0.2.8"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "linux-raw-sys"
@@ -165,9 +165,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "ppv-lite86"
@@ -190,9 +190,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
@@ -273,15 +273,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustix"
-version = "0.38.37"
+version = "0.38.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+checksum = "aa260229e6538e52293eeb577aabd09945a09d6d9cc0fc550ed7529056c2e32a"
 dependencies = [
  "bitflags",
  "errno",
@@ -304,22 +304,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.214"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.214"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -335,9 +335,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -346,9 +346,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -496,5 +496,5 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "autocfg"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "bit-set"
@@ -25,9 +25,15 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cfg-if"
@@ -37,7 +43,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "comparable"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "comparable_derive",
  "comparable_helper",
@@ -47,9 +53,9 @@ dependencies = [
 
 [[package]]
 name = "comparable_derive"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
- "convert_case 0.4.0",
+ "convert_case",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -57,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "comparable_helper"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
- "convert_case 0.6.0",
+ "convert_case",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -67,19 +73,13 @@ dependencies = [
 
 [[package]]
 name = "comparable_test"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "comparable",
  "pretty_assertions",
  "proptest",
  "serde",
 ]
-
-[[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "convert_case"
@@ -98,19 +98,19 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "errno"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.0.2"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "fnv"
@@ -120,9 +120,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -131,15 +131,15 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "libm"
@@ -149,31 +149,40 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.17"
+name = "once_cell"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "pretty_assertions"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
 dependencies = [
  "diff",
  "yansi",
@@ -181,18 +190,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
+checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
 dependencies = [
  "bit-set",
  "bit-vec",
@@ -216,9 +225,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -264,21 +273,21 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "rustix"
-version = "0.38.32"
+version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
+checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -295,22 +304,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -326,9 +335,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.55"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "002a1b3dbf967edfafc32655d0f377ab0bb7b994aa1d32c8cc7e9b8bf3ebb8f0"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -337,14 +346,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -355,15 +365,15 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "wait-timeout"
@@ -390,14 +400,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.52.4"
+name = "windows-sys"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
  "windows_i686_gnu",
+ "windows_i686_gnullvm",
  "windows_i686_msvc",
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
@@ -406,48 +426,75 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "yansi"
-version = "0.5.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,10 @@ comparable = { version = "0.5.5", path = "comparable" }
 comparable_derive = { version = "0.5.5", path = "comparable_derive" }
 comparable_helper = { version = "0.5.5", path = "comparable_helper" }
 comparable_test = { version = "0.5.5", path = "comparable_test" }
+
+convert_case = "0.6"
+pretty_assertions = "1.3"
+proc-macro2 = "1.0"
+quote = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+syn = { version = "1.0", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,12 @@ members = [
   "comparable_helper",
   "comparable_test",
 ]
+
+[workspace.package]
+version = "0.5.5"
+
+[workspace.dependencies]
+comparable = { version = "0.5.5", path = "comparable" }
+comparable_derive = { version = "0.5.5", path = "comparable_derive" }
+comparable_helper = { version = "0.5.5", path = "comparable_helper" }
+comparable_test = { version = "0.5.5", path = "comparable_test" }

--- a/comparable/Cargo.toml
+++ b/comparable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comparable"
-version = "0.5.4"
+version.workspace = true
 authors = ["John Wiegley"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -19,11 +19,11 @@ path = "src/lib.rs"
 [dependencies]
 pretty_assertions = "1.3"
 serde = { version = "1.0", features = ["derive"] }
-comparable_derive = { version = "0.5.4", optional = true, path = "../comparable_derive" }
-comparable_helper = { version = "0.5.4", path = "../comparable_helper" }
+comparable_derive = { workspace = true, optional = true }
+comparable_helper = { workspace = true }
 
 [dev-dependencies]
-comparable_derive = { version = "0.5.4", path = "../comparable_derive" }
+comparable_derive = { workspace = true }
 
 [package.metadata.playground]
 features = ["derive"]

--- a/comparable/Cargo.toml
+++ b/comparable/Cargo.toml
@@ -17,8 +17,8 @@ include = ["src/*.rs", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
 path = "src/lib.rs"
 
 [dependencies]
-pretty_assertions = "1.3"
-serde = { version = "1.0", features = ["derive"] }
+pretty_assertions = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 comparable_derive = { workspace = true, optional = true }
 comparable_helper = { workspace = true }
 

--- a/comparable_derive/Cargo.toml
+++ b/comparable_derive/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/lib.rs"
 [dependencies]
 syn = { version = "1.0", features = ["full"] }
 quote = "1.0"
-convert_case = "0.4"
+convert_case = "0.6"
 proc-macro2 = "1.0"
 
 [features]

--- a/comparable_derive/Cargo.toml
+++ b/comparable_derive/Cargo.toml
@@ -19,10 +19,10 @@ proc-macro = true
 path = "src/lib.rs"
 
 [dependencies]
-syn = { version = "1.0", features = ["full"] }
-quote = "1.0"
-convert_case = "0.6"
-proc-macro2 = "1.0"
+syn = { workspace = true, features = ["full"] }
+quote = { workspace = true }
+convert_case = { workspace = true }
+proc-macro2 = { workspace = true }
 
 [features]
 serde = []

--- a/comparable_derive/Cargo.toml
+++ b/comparable_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comparable_derive"
-version = "0.5.4"
+version.workspace = true
 authors = ["John Wiegley"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/comparable_derive/src/attrs.rs
+++ b/comparable_derive/src/attrs.rs
@@ -1,6 +1,6 @@
 use quote::format_ident;
 
-use crate::utils::has_attr;
+use crate::utils::{has_attr, has_attrs};
 
 pub struct Attributes {
 	pub describe_type: Option<syn::Type>,
@@ -13,6 +13,7 @@ pub struct Attributes {
 	pub comparable_private: bool,
 	pub comparable_desc_suffix: syn::Ident,
 	pub comparable_change_suffix: syn::Ident,
+	pub comparable_attributes: Vec<proc_macro2::TokenStream>,
 }
 
 impl Attributes {
@@ -34,6 +35,11 @@ impl Attributes {
 
 			comparable_desc_suffix: attr_to_ident(attrs, "comparable_desc_suffix", "Desc"),
 			comparable_change_suffix: attr_to_ident(attrs, "comparable_change_suffix", "Change"),
+
+			comparable_attributes: has_attrs(attrs, "comparable_attribute")
+				.into_iter()
+				.flat_map(syn::Attribute::parse_args)
+				.collect(),
 		}
 	}
 }

--- a/comparable_derive/src/definition.rs
+++ b/comparable_derive/src/definition.rs
@@ -57,6 +57,7 @@ impl Definition {
 				ty: Self::assoc_type(&r.field.ty, "Desc"),
 				..r.field.clone()
 			}),
+			&inputs.attrs.comparable_attributes,
 		);
 		Self {
 			ty: Some(
@@ -125,9 +126,15 @@ impl Definition {
 		let change_name = format_ident!("{}{}", type_name, inputs.attrs.comparable_change_suffix);
 		let change_type = Self::create_change_type(&inputs.attrs, &inputs.input.ident, &inputs.input.data).map(
 			|(ch_ty, helper_tys)| {
-				let ch_def = generate_type_definition(&inputs.visibility, &change_name, &ch_ty);
-				let helper_defs =
-					helper_tys.iter().map(|(name, ty)| generate_type_definition(&inputs.visibility, name, ty));
+				let ch_def = generate_type_definition(
+					&inputs.visibility,
+					&change_name,
+					&ch_ty,
+					&inputs.attrs.comparable_attributes,
+				);
+				let helper_defs = helper_tys.iter().map(|(name, ty)| {
+					generate_type_definition(&inputs.visibility, name, ty, &inputs.attrs.comparable_attributes)
+				});
 				quote! {
 					#ch_def
 					#(#helper_defs)*

--- a/comparable_derive/src/lib.rs
+++ b/comparable_derive/src/lib.rs
@@ -21,6 +21,7 @@ mod utils;
 		comparable_desc_suffix,
 		comparable_change_suffix,
 		comparable_ignore,
+		comparable_attribute,
 	)
 )]
 pub fn comparable_macro(input: proc_macro::TokenStream) -> proc_macro::TokenStream {

--- a/comparable_derive/src/utils.rs
+++ b/comparable_derive/src/utils.rs
@@ -23,6 +23,10 @@ pub fn has_attr<'a>(attrs: &'a [syn::Attribute], attr_name: &str) -> Option<&'a 
 	attrs.iter().find(|attr| attr.path.is_ident(attr_name))
 }
 
+pub fn has_attrs<'a>(attrs: &'a [syn::Attribute], attr_name: &str) -> Vec<&'a syn::Attribute> {
+	attrs.iter().filter(|attr| attr.path.is_ident(attr_name)).collect()
+}
+
 #[allow(dead_code)]
 pub fn data_from_variant(variant: &syn::Variant) -> syn::Data {
 	syn::Data::Struct(syn::DataStruct {
@@ -182,7 +186,12 @@ fn parse_synthetics(tokens: &TokenStream) -> Result<BTreeMap<syn::Ident, syn::Ex
 		.collect())
 }
 
-pub fn generate_type_definition(visibility: &syn::Visibility, type_name: &syn::Ident, data: &syn::Data) -> TokenStream {
+pub fn generate_type_definition(
+	visibility: &syn::Visibility,
+	type_name: &syn::Ident,
+	data: &syn::Data,
+	attributes: &[TokenStream],
+) -> TokenStream {
 	let (keyword, body) = match data {
 		syn::Data::Struct(st) => (
 			quote!(struct),
@@ -265,6 +274,7 @@ pub fn generate_type_definition(visibility: &syn::Visibility, type_name: &syn::I
 	quote! {
 		#derive_serde
 		#[derive(PartialEq, Debug)]
+	  #(#[#attributes])*
 		#visibility #keyword #type_name#body
 	}
 }

--- a/comparable_helper/Cargo.toml
+++ b/comparable_helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comparable_helper"
-version = "0.5.4"
+version.workspace = true
 authors = ["John Wiegley"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/comparable_helper/Cargo.toml
+++ b/comparable_helper/Cargo.toml
@@ -19,7 +19,7 @@ proc-macro = true
 path = "src/lib.rs"
 
 [dependencies]
-syn = { version = "1.0", features = ["full"] }
-quote = "1.0"
-convert_case = "0.6"
-proc-macro2 = "1.0"
+syn = { workspace = true, features = ["full"] }
+quote = { workspace = true }
+convert_case = { workspace = true }
+proc-macro2 = { workspace = true }

--- a/comparable_test/Cargo.toml
+++ b/comparable_test/Cargo.toml
@@ -18,7 +18,7 @@ name = "sample-test"
 path = "test/test.rs"
 
 [dev-dependencies]
-pretty_assertions = "1.3"
+pretty_assertions = { workspace = true }
 proptest = "1.0"
-serde = { version = "1.0", features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }
 comparable = { workspace = true, features = ["derive"] }

--- a/comparable_test/Cargo.toml
+++ b/comparable_test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comparable_test"
-version = "0.5.4"
+version.workspace = true
 authors = ["John Wiegley"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -21,4 +21,4 @@ path = "test/test.rs"
 pretty_assertions = "1.3"
 proptest = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-comparable = { version = "0.5.4", features = ["derive"], path = "../comparable" }
+comparable = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
Thanks for making `comparable`, I appreciate the work you've put into it! ❤️

This makes a handful of small(ish) changes to dependencies.

- bumps `convert_case` from `0.4` -> `0.6` (version was different between `comparable_derive` and `comparable_helper`).
- moves all shared dependencies to the workspace, so all packages depend on the same versions.
  - dependencies that were not shared remain at the package-level.
- uses workspace-level versioning, since these crates are interdependent and released together.
- bumps the crate version from `0.5.4` -> `0.5.5`, since none of these changes should break anything (tests still pass and no functionality was altered).

These changes are each a separate commit, in case any of these things are not desirable.

If you'd like me to revise or omit any of those, just let me know!

Thanks!