### PR TITLE
Adding the ability to ignore an enum field

### DIFF
--- a/README.md
+++ b/README.md
@@ -751,6 +751,29 @@ impl Comparable for MyEnum {
 }
 ```
 
+## Field attribute: `comparable_ignore`
+
+Similarly to structs, `#[comparable_ignore]` can be applied to enum variant
+fields that cannot be compared for differences.
+
+```
+#[derive(Comparable)]
+enum MyEnumWithNamedFields {
+    Variant1{ some_u8: u8},
+    Variant2 {
+        some_u16: u16,
+        #[comparable_ignore]
+        random_value: u64,
+    },
+}
+
+#[derive(Comparable)]
+enum MyEnumWithUnnamedFields {
+    Variant1(u8),
+    Variant2 (u16, #[comparable_ignore] u64),
+}
+```
+
 ## Deriving `Comparable` for enums: the `Desc` type
 
 By default for enums, deriving [`Comparable`] creates a "mirror" of that

--- a/comparable_derive/src/structs.rs
+++ b/comparable_derive/src/structs.rs
@@ -10,7 +10,7 @@ pub fn generate_describe_body_for_structs(desc_name: &syn::Ident, st: &syn::Data
 	match &st.fields {
 		syn::Fields::Named(named) => {
 			let (field_names, field_accessors): (Vec<syn::Ident>, Vec<syn::Expr>) =
-				map_fields(true, named.named.iter(), |r| {
+				map_fields(true, named.named.iter(), true, |r| {
 					(
 						r.field.ident.as_ref().expect("Found unnamed field in named struct").clone(),
 						(*r.accessor)(&format_ident!("self")),
@@ -25,7 +25,7 @@ pub fn generate_describe_body_for_structs(desc_name: &syn::Ident, st: &syn::Data
 			}
 		}
 		syn::Fields::Unnamed(unnamed) => {
-			let field_indices = map_fields(false, unnamed.unnamed.iter(), |r| syn::Index::from(r.index));
+			let field_indices = map_fields(false, unnamed.unnamed.iter(), true, |r| syn::Index::from(r.index));
 			quote! {
 				#desc_name(#(self.#field_indices.describe()),*)
 			}
@@ -71,8 +71,8 @@ pub fn create_change_type_for_structs(st: &syn::DataStruct) -> Option<syn::Data>
 			};
 
 			let variants = match &st.fields {
-				syn::Fields::Named(named) => map_fields(true, named.named.iter(), change_field),
-				syn::Fields::Unnamed(unnamed) => map_fields(true, unnamed.unnamed.iter(), change_field),
+				syn::Fields::Named(named) => map_fields(true, named.named.iter(), true, change_field),
+				syn::Fields::Unnamed(unnamed) => map_fields(true, unnamed.unnamed.iter(), true, change_field),
 				syn::Fields::Unit => Vec::new(),
 			};
 
@@ -87,7 +87,7 @@ pub fn create_change_type_for_structs(st: &syn::DataStruct) -> Option<syn::Data>
 
 pub fn generate_comparison_body_for_structs(change_name: &syn::Ident, st: &syn::DataStruct) -> TokenStream {
 	let (field_names_and_comparisons, field_variants): (Vec<(TokenStream, TokenStream)>, Vec<syn::Ident>) =
-		map_fields(true, st.fields.iter(), |r: &FieldRef| -> ((TokenStream, TokenStream), syn::Ident) {
+		map_fields(true, st.fields.iter(), true, |r: &FieldRef| -> ((TokenStream, TokenStream), syn::Ident) {
 			let idx = syn::Index::from(r.index);
 			let (name, variant) = if let Some(name) = r.field.ident.as_ref() {
 				(quote!(#name), syn::Ident::new(&name.to_string().to_case(Case::Pascal), Span::call_site()))

--- a/comparable_test/test/enums.rs
+++ b/comparable_test/test/enums.rs
@@ -332,3 +332,218 @@ fn test_enum_fields_varying_visibility() {
 		Changed(VisiblePrivateChange::BothField { int: I32Change(1, 4) }),
 	);
 }
+
+#[test]
+fn test_enum_1_variant_1_unnamed_field_1_ignored() {
+	#[derive(Comparable)]
+	enum UnitEnum {
+		Field(#[comparable_ignore] u8),
+	}
+
+	assert_changes!(&UnitEnum::Field(0), &UnitEnum::Field(1), Unchanged);
+}
+
+#[test]
+fn test_enum_1_variant_2_unnamed_field_first_ignored() {
+	#[derive(Comparable)]
+	enum UnitEnum {
+		Field(#[comparable_ignore] u8, u16),
+	}
+
+	assert_changes!(&UnitEnum::Field(0, 0), &UnitEnum::Field(1, 0), Unchanged);
+	assert_changes!(
+		&UnitEnum::Field(0, 0),
+		&UnitEnum::Field(1, 1),
+		Changed(UnitEnumChange::BothField(Changed(U16Change(0, 1))))
+	);
+}
+
+#[test]
+fn test_enum_1_variant_2_unnamed_field_second_ignored() {
+	#[derive(Comparable)]
+	enum UnitEnum {
+		Field(u8, #[comparable_ignore] u16),
+	}
+
+	assert_changes!(&UnitEnum::Field(0, 0), &UnitEnum::Field(0, 1), Unchanged);
+	assert_changes!(
+		&UnitEnum::Field(0, 0),
+		&UnitEnum::Field(1, 1),
+		Changed(UnitEnumChange::BothField(Changed(U8Change(0, 1))))
+	);
+}
+
+#[test]
+fn test_enum_1_variant_3_unnamed_field_first_third_ignored() {
+	#[derive(Comparable)]
+	enum UnitEnum {
+		Field(#[comparable_ignore] u8, u16, #[comparable_ignore] u32),
+	}
+
+	assert_changes!(&UnitEnum::Field(0, 0, 0), &UnitEnum::Field(1, 0, 1), Unchanged);
+	assert_changes!(
+		&UnitEnum::Field(0, 0, 0),
+		&UnitEnum::Field(1, 1, 0),
+		Changed(UnitEnumChange::BothField(Changed(U16Change(0, 1))))
+	);
+	assert_changes!(
+		&UnitEnum::Field(0, 0, 0),
+		&UnitEnum::Field(1, 1, 1),
+		Changed(UnitEnumChange::BothField(Changed(U16Change(0, 1))))
+	);
+}
+
+#[test]
+fn test_enum_2_variant_2_unnamed_field_1_ignored() {
+	#[derive(Comparable)]
+	enum TwoVariantEnum {
+		Field1(#[comparable_ignore] u8, u16),
+		Field2(u32),
+	}
+
+	assert_changes!(&TwoVariantEnum::Field1(0, 0), &TwoVariantEnum::Field1(1, 0), Unchanged);
+	assert_changes!(&TwoVariantEnum::Field2(1), &TwoVariantEnum::Field2(1), Unchanged);
+	assert_changes!(
+		&TwoVariantEnum::Field2(1),
+		&TwoVariantEnum::Field2(0),
+		Changed(TwoVariantEnumChange::BothField2(U32Change(1, 0)))
+	);
+	assert_changes!(
+		&TwoVariantEnum::Field1(1, 0),
+		&TwoVariantEnum::Field2(0),
+		Changed(TwoVariantEnumChange::Different(TwoVariantEnumDesc::Field1(0), TwoVariantEnumDesc::Field2(0)))
+	);
+	assert_changes!(
+		&TwoVariantEnum::Field1(0, 0),
+		&TwoVariantEnum::Field1(1, 1),
+		Changed(TwoVariantEnumChange::BothField1(Changed(U16Change(0, 1))))
+	);
+}
+
+#[test]
+fn test_enum_1_variant_1_named_field_1_ignored() {
+	#[derive(Comparable)]
+	enum UnitEnum {
+		Field {
+			#[comparable_ignore]
+			some_u8: u8,
+		},
+	}
+
+	assert_changes!(&UnitEnum::Field { some_u8: 0 }, &UnitEnum::Field { some_u8: 1 }, Unchanged);
+}
+
+#[test]
+fn test_enum_1_variant_2_named_field_first_ignored() {
+	#[derive(Comparable)]
+	enum UnitEnum {
+		Field {
+			#[comparable_ignore]
+			some_u8: u8,
+			some_u16: u16,
+		},
+	}
+
+	assert_changes!(
+		&UnitEnum::Field { some_u8: 0, some_u16: 0 },
+		&UnitEnum::Field { some_u8: 1, some_u16: 0 },
+		Unchanged
+	);
+	assert_changes!(
+		&UnitEnum::Field { some_u8: 0, some_u16: 0 },
+		&UnitEnum::Field { some_u8: 1, some_u16: 1 },
+		Changed(UnitEnumChange::BothField { some_u16: Changed(U16Change(0, 1)) })
+	);
+}
+
+#[test]
+fn test_enum_1_variant_2_named_field_second_ignored() {
+	#[derive(Comparable)]
+	enum UnitEnum {
+		Field {
+			some_u8: u8,
+			#[comparable_ignore]
+			some_u16: u16,
+		},
+	}
+	assert_changes!(
+		&UnitEnum::Field { some_u8: 0, some_u16: 0 },
+		&UnitEnum::Field { some_u8: 0, some_u16: 1 },
+		Unchanged
+	);
+	assert_changes!(
+		&UnitEnum::Field { some_u8: 0, some_u16: 0 },
+		&UnitEnum::Field { some_u8: 1, some_u16: 1 },
+		Changed(UnitEnumChange::BothField { some_u8: Changed(U8Change(0, 1)) })
+	);
+}
+
+#[test]
+fn test_enum_1_variant_3_named_field_first_third_ignored() {
+	#[derive(Comparable)]
+	enum UnitEnum {
+		Field {
+			#[comparable_ignore]
+			some_u8: u8,
+			some_u16: u16,
+			#[comparable_ignore]
+			some_u32: u32,
+		},
+	}
+
+	assert_changes!(
+		&UnitEnum::Field { some_u8: 0, some_u16: 0, some_u32: 0 },
+		&UnitEnum::Field { some_u8: 1, some_u16: 0, some_u32: 1 },
+		Unchanged
+	);
+	assert_changes!(
+		&UnitEnum::Field { some_u8: 0, some_u16: 0, some_u32: 0 },
+		&UnitEnum::Field { some_u8: 1, some_u16: 1, some_u32: 0 },
+		Changed(UnitEnumChange::BothField { some_u16: Changed(U16Change(0, 1)) })
+	);
+	assert_changes!(
+		&UnitEnum::Field { some_u8: 0, some_u16: 0, some_u32: 0 },
+		&UnitEnum::Field { some_u8: 1, some_u16: 1, some_u32: 1 },
+		Changed(UnitEnumChange::BothField { some_u16: Changed(U16Change(0, 1)) })
+	);
+}
+
+#[test]
+fn test_enum_2_variant_2_named_field_1_ignored() {
+	#[derive(Comparable)]
+	enum TwoVariantEnum {
+		Field1 {
+			#[comparable_ignore]
+			some_u8: u8,
+			some_u16: u16,
+		},
+		Field2 {
+			some_u32: u32,
+		},
+	}
+
+	assert_changes!(
+		&TwoVariantEnum::Field1 { some_u8: 0, some_u16: 0 },
+		&TwoVariantEnum::Field1 { some_u8: 1, some_u16: 0 },
+		Unchanged
+	);
+	assert_changes!(&TwoVariantEnum::Field2 { some_u32: 1 }, &TwoVariantEnum::Field2 { some_u32: 1 }, Unchanged);
+	assert_changes!(
+		&TwoVariantEnum::Field2 { some_u32: 1 },
+		&TwoVariantEnum::Field2 { some_u32: 0 },
+		Changed(TwoVariantEnumChange::BothField2 { some_u32: U32Change(1, 0) })
+	);
+	assert_changes!(
+		&TwoVariantEnum::Field1 { some_u8: 1, some_u16: 0 },
+		&TwoVariantEnum::Field2 { some_u32: 0 },
+		Changed(TwoVariantEnumChange::Different(
+			TwoVariantEnumDesc::Field1 { some_u16: 0 },
+			TwoVariantEnumDesc::Field2 { some_u32: 0 }
+		))
+	);
+	assert_changes!(
+		&TwoVariantEnum::Field1 { some_u8: 0, some_u16: 0 },
+		&TwoVariantEnum::Field1 { some_u8: 1, some_u16: 1 },
+		Changed(TwoVariantEnumChange::BothField1 { some_u16: Changed(U16Change(0, 1)) })
+	);
+}


### PR DESCRIPTION
This PR adds the ability to ignore an enum field using the `#[comparable_ignore]` attribute, just like it is possible with structs.

Deriving the following struct
```rust
#[derive(Comparable)]
enum B {
    A,
    B { #[comparable_ignore] some_u8: u8, some_u16: u16 },
}
```

produces

```rust
enum BDesc {
    A,
    B { some_u16: <u16 as comparable::Comparable>::Desc },
}

enum BChange {
    BothB { some_u16: comparable::Changed<<u16 as comparable::Comparable>::Change> },
    Different(<B as comparable::Comparable>::Desc, <B as comparable::Comparable>::Desc),
}

impl comparable::Comparable for B {
    type Desc = BDesc;
    fn describe(&self) -> Self::Desc {
        match self {
            B::A => BDesc::A,
            B::B { some_u8: var0, some_u16: var1 } => {
                BDesc::B {
                    some_u16: var1.describe(),
                }
            }
        }
    }
    type Change = BChange;
    fn comparison(&self, other: &Self) -> comparable::Changed<Self::Change> {
        match (self, other) {
            (B::A, B::A) => comparable::Changed::Unchanged,
            (
                B::B { some_u8: self_var0, some_u16: self_var1 },
                B::B { some_u8: other_var0, some_u16: other_var1 },
            ) => {
                let changes_var1 = self_var1.comparison(&other_var1);
                if changes_var1.is_unchanged() {
                    comparable::Changed::Unchanged
                } else {
                    comparable::Changed::Changed(BChange::BothB {
                        some_u16: changes_var1,
                    })
                }
            }
            (_, _) => {
                comparable::Changed::Changed(
                    BChange::Different(self.describe(), other.describe()),
                )
            }
        }
    }
}
```

Feel free to ask for changes if you're not satisfied with the actual code.