### PR TITLE
Adds feature to allow passing attributes through to derived types (also updates dependencies and unifies workspace versioning)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,7 +135,7 @@ dependencies = [
 name = "comparable_derive"
 version = "0.5.6"
 dependencies = [
- "convert_case 0.4.0",
+ "convert_case",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -145,7 +145,7 @@ dependencies = [
 name = "comparable_helper"
 version = "0.5.6"
 dependencies = [
- "convert_case 0.6.0",
+ "convert_case",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -160,12 +160,6 @@ dependencies = [
  "proptest",
  "serde",
 ]
-
-[[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "convert_case"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,10 @@ comparable = { version = "0.5.6", path = "comparable" }
 comparable_derive = { version = "0.5.6", path = "comparable_derive" }
 comparable_helper = { version = "0.5.6", path = "comparable_helper" }
 comparable_test = { version = "0.5.6", path = "comparable_test" }
+
+convert_case = "0.6"
+pretty_assertions = "1.3"
+proc-macro2 = "1.0"
+quote = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+syn = { version = "1.0", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,12 @@ exclude = ["fuzz"]
 # does not apply this table to dependencies, nor to downstream users of the
 # published crates.
 warnings = "deny"
+
+[workspace.package]
+version = "0.5.6"
+
+[workspace.dependencies]
+comparable = { version = "0.5.6", path = "comparable" }
+comparable_derive = { version = "0.5.6", path = "comparable_derive" }
+comparable_helper = { version = "0.5.6", path = "comparable_helper" }
+comparable_test = { version = "0.5.6", path = "comparable_test" }

--- a/comparable/Cargo.toml
+++ b/comparable/Cargo.toml
@@ -17,8 +17,8 @@ include = ["src/*.rs", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
 path = "src/lib.rs"
 
 [dependencies]
-pretty_assertions = "1.3"
-serde = { version = "1.0", features = ["derive"] }
+pretty_assertions = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 comparable_derive = { workspace = true, optional = true }
 comparable_helper = { workspace = true }
 

--- a/comparable/Cargo.toml
+++ b/comparable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comparable"
-version = "0.5.6"
+version.workspace = true
 authors = ["John Wiegley"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -19,11 +19,11 @@ path = "src/lib.rs"
 [dependencies]
 pretty_assertions = "1.3"
 serde = { version = "1.0", features = ["derive"] }
-comparable_derive = { version = "0.5.6", optional = true, path = "../comparable_derive" }
-comparable_helper = { version = "0.5.6", path = "../comparable_helper" }
+comparable_derive = { workspace = true, optional = true }
+comparable_helper = { workspace = true }
 
 [dev-dependencies]
-comparable_derive = { version = "0.5.6", path = "../comparable_derive" }
+comparable_derive = { workspace = true }
 criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }
 
 [[bench]]

--- a/comparable_derive/Cargo.toml
+++ b/comparable_derive/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/lib.rs"
 [dependencies]
 syn = { version = "1.0", features = ["full"] }
 quote = "1.0"
-convert_case = "0.4"
+convert_case = "0.6"
 proc-macro2 = "1.0"
 
 [features]

--- a/comparable_derive/Cargo.toml
+++ b/comparable_derive/Cargo.toml
@@ -19,10 +19,10 @@ proc-macro = true
 path = "src/lib.rs"
 
 [dependencies]
-syn = { version = "1.0", features = ["full"] }
-quote = "1.0"
-convert_case = "0.6"
-proc-macro2 = "1.0"
+syn = { workspace = true, features = ["full"] }
+quote = { workspace = true }
+convert_case = { workspace = true }
+proc-macro2 = { workspace = true }
 
 [features]
 serde = []

--- a/comparable_derive/Cargo.toml
+++ b/comparable_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comparable_derive"
-version = "0.5.6"
+version.workspace = true
 authors = ["John Wiegley"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/comparable_derive/src/attrs.rs
+++ b/comparable_derive/src/attrs.rs
@@ -1,6 +1,6 @@
 use quote::format_ident;
 
-use crate::utils::has_attr;
+use crate::utils::{has_attr, has_attrs};
 
 pub struct Attributes {
 	pub describe_type: Option<syn::Type>,
@@ -13,6 +13,7 @@ pub struct Attributes {
 	pub comparable_private: bool,
 	pub comparable_desc_suffix: syn::Ident,
 	pub comparable_change_suffix: syn::Ident,
+	pub comparable_attributes: Vec<proc_macro2::TokenStream>,
 }
 
 impl Attributes {
@@ -34,6 +35,11 @@ impl Attributes {
 
 			comparable_desc_suffix: attr_to_ident(attrs, "comparable_desc_suffix", "Desc"),
 			comparable_change_suffix: attr_to_ident(attrs, "comparable_change_suffix", "Change"),
+
+			comparable_attributes: has_attrs(attrs, "comparable_attribute")
+				.into_iter()
+				.flat_map(syn::Attribute::parse_args)
+				.collect(),
 		}
 	}
 }

--- a/comparable_derive/src/definition.rs
+++ b/comparable_derive/src/definition.rs
@@ -58,6 +58,7 @@ impl Definition {
 				..r.field.clone()
 			}),
 			&inputs.input.generics,
+			&inputs.attrs.comparable_attributes,
 		);
 		let (_impl_generics, ty_generics, _where_clause) = inputs.input.generics.split_for_impl();
 		Self {
@@ -128,10 +129,21 @@ impl Definition {
 		let change_type =
 			Self::create_change_type(&inputs.attrs, &inputs.input.ident, &inputs.input.data, &inputs.input.generics)
 				.map(|(ch_ty, helper_tys)| {
-					let ch_def =
-						generate_type_definition(&inputs.visibility, &change_name, &ch_ty, &inputs.input.generics);
+					let ch_def = generate_type_definition(
+						&inputs.visibility,
+						&change_name,
+						&ch_ty,
+						&inputs.input.generics,
+						&inputs.attrs.comparable_attributes,
+					);
 					let helper_defs = helper_tys.iter().map(|(name, ty)| {
-						generate_type_definition(&inputs.visibility, name, ty, &inputs.input.generics)
+						generate_type_definition(
+							&inputs.visibility,
+							name,
+							ty,
+							&inputs.input.generics,
+							&inputs.attrs.comparable_attributes,
+						)
 					});
 					quote! {
 						#ch_def

--- a/comparable_derive/src/lib.rs
+++ b/comparable_derive/src/lib.rs
@@ -21,6 +21,7 @@ mod utils;
 		comparable_desc_suffix,
 		comparable_change_suffix,
 		comparable_ignore,
+		comparable_attribute,
 	)
 )]
 pub fn comparable_macro(input: proc_macro::TokenStream) -> proc_macro::TokenStream {

--- a/comparable_derive/src/utils.rs
+++ b/comparable_derive/src/utils.rs
@@ -19,6 +19,10 @@ pub fn has_attr<'a>(attrs: &'a [syn::Attribute], attr_name: &str) -> Option<&'a 
 	attrs.iter().find(|attr| attr.path.is_ident(attr_name))
 }
 
+pub fn has_attrs<'a>(attrs: &'a [syn::Attribute], attr_name: &str) -> Vec<&'a syn::Attribute> {
+	attrs.iter().filter(|attr| attr.path.is_ident(attr_name)).collect()
+}
+
 #[allow(dead_code)]
 pub fn data_from_variant(variant: &syn::Variant) -> syn::Data {
 	syn::Data::Struct(syn::DataStruct {
@@ -184,6 +188,7 @@ pub fn generate_type_definition(
 	type_name: &syn::Ident,
 	data: &syn::Data,
 	generics: &syn::Generics,
+	attributes: &[TokenStream],
 ) -> TokenStream {
 	let (impl_generics, _ty_generics, where_clause) = generics.split_for_impl();
 
@@ -294,6 +299,7 @@ pub fn generate_type_definition(
 	quote! {
 		#derive_serde
 		#[derive(PartialEq, Debug)]
+		#(#[#attributes])*
 		#visibility #keyword #type_name#impl_generics#body
 	}
 }

--- a/comparable_helper/Cargo.toml
+++ b/comparable_helper/Cargo.toml
@@ -19,10 +19,10 @@ proc-macro = true
 path = "src/lib.rs"
 
 [dependencies]
-syn = { version = "1.0", features = ["full"] }
-quote = "1.0"
-convert_case = "0.6"
-proc-macro2 = "1.0"
+syn = { workspace = true, features = ["full"] }
+quote = { workspace = true }
+convert_case = { workspace = true }
+proc-macro2 = { workspace = true }
 
 [lints]
 workspace = true

--- a/comparable_helper/Cargo.toml
+++ b/comparable_helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comparable_helper"
-version = "0.5.6"
+version.workspace = true
 authors = ["John Wiegley"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/comparable_test/Cargo.toml
+++ b/comparable_test/Cargo.toml
@@ -22,9 +22,9 @@ name = "generic_enum_test"
 path = "test/generic_enum_test.rs"
 
 [dev-dependencies]
-pretty_assertions = "1.3"
+pretty_assertions = { workspace = true }
 proptest = "1.0"
-serde = { version = "1.0", features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }
 comparable = { workspace = true, features = ["derive"] }
 
 [lints]

--- a/comparable_test/Cargo.toml
+++ b/comparable_test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comparable_test"
-version = "0.5.6"
+version.workspace = true
 authors = ["John Wiegley"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -25,7 +25,7 @@ path = "test/generic_enum_test.rs"
 pretty_assertions = "1.3"
 proptest = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-comparable = { version = "0.5.6", features = ["derive"], path = "../comparable" }
+comparable = { workspace = true, features = ["derive"] }
 
 [lints]
 workspace = true


### PR DESCRIPTION
Supersedes #5; re-targeted to the `colstrom/passing-attrs` branch (identical content). Original work by @colstrom.