### PR TITLE
Make Desc/Change serializable through generics (fixes #12)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,7 @@ dependencies = [
  "pretty_assertions",
  "proptest",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ SHELL := bash
 CARGO_TARGET_DIR ?= target
 TARGET = $(HOME)/dfinity/fixtures/rs/comparable
 
-.PHONY: all help gen-lib build check test doc docs docs-open \
+.PHONY: all help gen-lib build check test test-serde doc docs docs-open \
 	fmt fmt-check lint clippy nix-lint shell-lint \
 	coverage coverage-lcov coverage-check coverage-baseline \
 	bench perf-check perf-baseline perf-compare \
@@ -42,6 +42,9 @@ build: ## Build the workspace (warnings denied via [lints])
 
 test: ## Run unit, integration and doc tests
 	cargo test --workspace
+
+test-serde: ## Run the serde-enabled regression tests (issue #12)
+	cargo test -p comparable_test --features serde --test serde
 
 check: ## Type-check the workspace
 	cargo check --workspace --all-targets
@@ -135,7 +138,7 @@ fuzz-smoke: ## Short fuzz run for CI (needs nightly shell)
 audit: ## Audit dependencies for security advisories
 	cargo audit
 
-ci: fmt-check lint build test doc ## Fast checks (pre-commit / nix flake check)
+ci: fmt-check lint build test test-serde doc ## Fast checks (pre-commit / nix flake check)
 
 clean: ## Remove generated artifacts
 	rm -f lcov.info

--- a/comparable/src/array.rs
+++ b/comparable/src/array.rs
@@ -1,11 +1,22 @@
-use crate::types::{Changed, Comparable};
+use crate::types::{Changed, Comparable, MaybeSerde};
 use std::convert::TryInto;
 
 fn convert_vec_to_array<T, const N: usize>(v: Vec<T>) -> [T; N] {
 	v.try_into().unwrap_or_else(|v: Vec<T>| panic!("Expected a Vec of length {} but it was {}", N, v.len()))
 }
 
-impl<T: Comparable, const N: usize> Comparable for [T; N] {
+// The `Desc`/`Change` types here are arrays, and serde only implements
+// `Serialize`/`Deserialize` for arrays up to a fixed length (it has no
+// const-generic array impl).  We therefore cannot prove `MaybeSerde` for a
+// *generic* `N` at the impl site, so we make it a premise via the `where`
+// clause: with the `serde` feature off it is vacuous (every type is
+// `MaybeSerde`), and with it on it is satisfied at every concrete `N` that
+// serde itself supports.
+impl<T: Comparable, const N: usize> Comparable for [T; N]
+where
+	[T::Desc; N]: MaybeSerde,
+	[Changed<T::Change>; N]: MaybeSerde,
+{
 	type Desc = [T::Desc; N];
 
 	fn describe(&self) -> Self::Desc {

--- a/comparable/src/map.rs
+++ b/comparable/src/map.rs
@@ -2,7 +2,7 @@
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::Debug;
 
-use crate::types::{Changed, Comparable};
+use crate::types::{Changed, Comparable, MaybeSerde};
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(PartialEq, Debug)]
@@ -12,7 +12,7 @@ pub enum MapChange<Key, Desc, Change> {
 	Removed(Key),
 }
 
-impl<Key: Ord + Clone + Debug, Value: Comparable> Comparable for BTreeMap<Key, Value> {
+impl<Key: Ord + Clone + Debug + MaybeSerde, Value: Comparable> Comparable for BTreeMap<Key, Value> {
 	type Desc = BTreeMap<Key, Value::Desc>;
 
 	fn describe(&self) -> Self::Desc {
@@ -59,7 +59,7 @@ fn to_btreemap<K: Clone + Ord, V>(map: &HashMap<K, V>) -> BTreeMap<K, &V> {
 	map.iter().map(|(k, v)| (k.clone(), v)).collect::<BTreeMap<K, &V>>().into_iter().collect()
 }
 
-impl<Key: Ord + Clone + Debug, Value: Comparable> Comparable for HashMap<Key, Value> {
+impl<Key: Ord + Clone + Debug + MaybeSerde, Value: Comparable> Comparable for HashMap<Key, Value> {
 	type Desc = BTreeMap<Key, Value::Desc>;
 
 	fn describe(&self) -> Self::Desc {

--- a/comparable/src/path.rs
+++ b/comparable/src/path.rs
@@ -1,6 +1,7 @@
 use crate::types::{Changed, Comparable};
 use std::path::{Path, PathBuf};
 
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(PartialEq, Debug)]
 pub struct PathBufChange(pub PathBuf, pub PathBuf);
 

--- a/comparable/src/types.rs
+++ b/comparable/src/types.rs
@@ -72,12 +72,39 @@ impl<T> Iterator for Changed<T> {
 	}
 }
 
+/// A bound shared by every [`Comparable::Desc`] and [`Comparable::Change`]
+/// type.
+///
+/// When the `serde` feature is enabled this requires `Serialize` and
+/// `DeserializeOwned`, so that descriptions and change sets can be serialized
+/// even through a generic `T: Comparable` (where the concrete `Desc`/`Change`
+/// types — and therefore their derived serde impls — are not yet known). When
+/// the feature is disabled it is an empty, blanket-implemented marker that adds
+/// no constraint.
+///
+/// This is an implementation detail of the trait's bounds and is not meant to
+/// be named or implemented directly.
+#[cfg(feature = "serde")]
+#[doc(hidden)]
+pub trait MaybeSerde: serde::Serialize + serde::de::DeserializeOwned {}
+#[cfg(feature = "serde")]
+impl<T: serde::Serialize + serde::de::DeserializeOwned> MaybeSerde for T {}
+
+#[cfg(not(feature = "serde"))]
+#[doc(hidden)]
+pub trait MaybeSerde {}
+#[cfg(not(feature = "serde"))]
+impl<T> MaybeSerde for T {}
+
 pub trait Comparable {
 	/// Describes the type under consideration. For types that use
 	/// `#[derive(Comparable)]` this is a mirror of the type itself, where all
 	/// field types refer to the `Comparable::Desc` associated type of the
 	/// original type.
-	type Desc: PartialEq + Debug;
+	///
+	/// With the `serde` feature enabled this type is always `Serialize` and
+	/// `DeserializeOwned`.
+	type Desc: PartialEq + Debug + MaybeSerde;
 
 	/// Describe a value of a type.
 	fn describe(&self) -> Self::Desc;
@@ -86,7 +113,10 @@ pub trait Comparable {
 	/// this type depends on the type being compared, for example, singleton
 	/// struts vary from structs with multiple fields. Please see the [full
 	/// documentation](https://docs.rs/comparable) for more details.
-	type Change: PartialEq + Debug;
+	///
+	/// With the `serde` feature enabled this type is always `Serialize` and
+	/// `DeserializeOwned`.
+	type Change: PartialEq + Debug + MaybeSerde;
 
 	/// Compare two values of a type, reporting whether they differ and what
 	/// the complete set of differences looks like. This is used by the

--- a/comparable_derive/src/definition.rs
+++ b/comparable_derive/src/definition.rs
@@ -171,6 +171,7 @@ impl Definition {
 				&inputs.attrs,
 				type_name,
 				&change_name,
+				&inputs.input.generics,
 				&inputs.input.data,
 			),
 		}
@@ -202,10 +203,11 @@ impl Definition {
 		attrs: &Attributes,
 		type_name: &syn::Ident,
 		change_name: &syn::Ident,
+		generics: &syn::Generics,
 		data: &syn::Data,
 	) -> TokenStream {
 		match data {
-			syn::Data::Struct(st) => generate_comparison_body_for_structs(change_name, st),
+			syn::Data::Struct(st) => generate_comparison_body_for_structs(change_name, generics, st),
 			syn::Data::Enum(en) => {
 				if en.variants.is_empty() {
 					quote! {

--- a/comparable_derive/src/structs.rs
+++ b/comparable_derive/src/structs.rs
@@ -85,7 +85,12 @@ pub fn create_change_type_for_structs(st: &syn::DataStruct) -> Option<syn::Data>
 	}
 }
 
-pub fn generate_comparison_body_for_structs(change_name: &syn::Ident, st: &syn::DataStruct) -> TokenStream {
+pub fn generate_comparison_body_for_structs(
+	change_name: &syn::Ident,
+	generics: &syn::Generics,
+	st: &syn::DataStruct,
+) -> TokenStream {
+	let (_impl_generics, ty_generics, _where_clause) = generics.split_for_impl();
 	let (field_names_and_comparisons, field_variants): (Vec<(TokenStream, TokenStream)>, Vec<syn::Ident>) =
 		map_fields(true, st.fields.iter(), true, |r: &FieldRef| -> ((TokenStream, TokenStream), syn::Ident) {
 			let idx = syn::Index::from(r.index);
@@ -117,7 +122,7 @@ pub fn generate_comparison_body_for_structs(change_name: &syn::Ident, st: &syn::
 		}
 	} else {
 		quote! {
-			let changes: Vec<#change_name> = vec![
+			let changes: Vec<#change_name #ty_generics> = vec![
 				#(#comparisons.map(#change_name::#field_variants)),*
 			]
 				.into_iter()

--- a/comparable_derive/src/utils.rs
+++ b/comparable_derive/src/utils.rs
@@ -289,13 +289,37 @@ pub fn generate_type_definition(
 			panic!("comparable_derive::generate_type_definition not implemented for unions")
 		}
 	};
-	let derive_serde = if cfg!(feature = "serde") {
-		quote! {
-			#[derive(serde::Serialize, serde::Deserialize)]
+	// serde infers a `T: Serialize`/`T: Deserialize` bound for every generic type
+	// parameter, but the fields of the generated type are associated types like
+	// `<T as Comparable>::Desc`, not `T` itself. Override that inference with
+	// `T: comparable::Comparable`: with the `serde` feature on, `Comparable`
+	// guarantees its `Desc`/`Change` associated types are `Serialize +
+	// DeserializeOwned`, so this is exactly the bound the derived impls need (and
+	// it avoids spuriously requiring `T: Serialize`).
+	#[cfg(feature = "serde")]
+	let derive_serde = {
+		let type_param_bounds: Vec<String> = generics
+			.params
+			.iter()
+			.filter_map(|param| match param {
+				syn::GenericParam::Type(type_param) => Some(format!("{}: comparable::Comparable", type_param.ident)),
+				_ => None,
+			})
+			.collect();
+		if type_param_bounds.is_empty() {
+			quote! {
+				#[derive(serde::Serialize, serde::Deserialize)]
+			}
+		} else {
+			let bound = type_param_bounds.join(", ");
+			quote! {
+				#[derive(serde::Serialize, serde::Deserialize)]
+				#[serde(bound = #bound)]
+			}
 		}
-	} else {
-		quote! {}
 	};
+	#[cfg(not(feature = "serde"))]
+	let derive_serde = quote! {};
 	quote! {
 		#derive_serde
 		#[derive(PartialEq, Debug)]

--- a/comparable_test/Cargo.toml
+++ b/comparable_test/Cargo.toml
@@ -21,10 +21,21 @@ path = "test/test.rs"
 name = "generic_enum_test"
 path = "test/generic_enum_test.rs"
 
+[[test]]
+name = "serde"
+path = "test/serde.rs"
+required-features = ["serde"]
+
+[features]
+# Build the test suite (and the `comparable` dependency) with serde support,
+# so the serde regression tests in `test/serde.rs` are compiled and run.
+serde = ["comparable/serde"]
+
 [dev-dependencies]
 pretty_assertions = { workspace = true }
 proptest = "1.0"
 serde = { workspace = true, features = ["derive"] }
+serde_json = "1.0"
 comparable = { workspace = true, features = ["derive"] }
 
 [lints]

--- a/comparable_test/test/generic_enum_test.rs
+++ b/comparable_test/test/generic_enum_test.rs
@@ -10,6 +10,22 @@ pub enum IdOrObject<T: PartialEq + Debug> {
 	Object(T),
 }
 
+// A generic struct with a single field: its `Change` type is the field's
+// change directly (no `Vec`).
+#[derive(Debug, PartialEq, Comparable)]
+pub struct Single<T: PartialEq + Debug> {
+	pub value: T,
+}
+
+// A generic struct with multiple fields: its `Change` is a `Vec<PairChange<T>>`.
+// Regression test for the derive macro emitting `Vec<PairChange>` (missing the
+// `<T>`) in the generated `comparison` body, which failed to compile (E0107).
+#[derive(Debug, PartialEq, Comparable)]
+pub struct Pair<T: PartialEq + Debug> {
+	pub name: String,
+	pub value: T,
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -30,5 +46,48 @@ mod tests {
 
 		let changes = obj1.comparison(&obj2);
 		println!("Changes: {:?}", changes);
+	}
+
+	#[test]
+	fn test_generic_struct_single_field() {
+		use comparable::Changed;
+		let a = Single { value: 1i32 };
+		let b = Single { value: 1i32 };
+		assert!(a.comparison(&b).is_unchanged());
+
+		let c = Single { value: 2i32 };
+		assert!(matches!(a.comparison(&c), Changed::Changed(_)));
+	}
+
+	#[test]
+	fn test_generic_struct_multi_field() {
+		use comparable::Changed;
+
+		// Unchanged.
+		let a = Pair { name: "x".to_string(), value: 1i32 };
+		let b = Pair { name: "x".to_string(), value: 1i32 };
+		assert!(a.comparison(&b).is_unchanged());
+
+		// Both fields changed -> exactly two entries, in field order.
+		let c = Pair { name: "y".to_string(), value: 2i32 };
+		match a.comparison(&c) {
+			Changed::Changed(changes) => {
+				assert_eq!(
+					changes,
+					vec![
+						PairChange::Name(comparable::StringChange("x".to_string(), "y".to_string())),
+						PairChange::Value(comparable::I32Change(1, 2)),
+					]
+				);
+			}
+			Changed::Unchanged => panic!("expected a change"),
+		}
+
+		// Only one field changed -> exactly one entry.
+		let d = Pair { name: "x".to_string(), value: 99i32 };
+		match a.comparison(&d) {
+			Changed::Changed(changes) => assert_eq!(changes.len(), 1),
+			Changed::Unchanged => panic!("expected a change"),
+		}
 	}
 }

--- a/comparable_test/test/serde.rs
+++ b/comparable_test/test/serde.rs
@@ -1,0 +1,145 @@
+//! Regression tests for https://github.com/jwiegley/comparable/issues/12:
+//! "Can't serialize changes".
+//!
+//! With the `serde` feature enabled, every `Comparable::Desc` and
+//! `Comparable::Change` type derives `Serialize`/`Deserialize`.  Before the
+//! fix, this guarantee was invisible in a *generic* context, because the
+//! `Comparable` trait did not bound its associated types with `Serialize`.
+//! That broke two things, both reproduced verbatim below:
+//!
+//!   1. A `#[derive(Serialize)]` type with a `<T as Comparable>::Change` field
+//!      (the reporter's `DiffReport`) failed to compile.
+//!   2. `#[derive(Comparable)]` on a generic type that *also* derived
+//!      `Serialize` failed to compile, because the generated `Desc`/`Change`
+//!      types could not prove `<T as Comparable>::Desc: Serialize`.
+//!
+//! This target is only built when the `serde` feature is on (see
+//! `required-features` in `comparable_test/Cargo.toml`).
+
+#![allow(dead_code)]
+
+use comparable::{Changed, Comparable};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fmt::Debug;
+
+// --- Compile-time guarantees ------------------------------------------------
+//
+// These functions never run; they exist so the build fails if any built-in or
+// derived `Desc`/`Change` type stops being serde-serializable.
+
+fn assert_serialize<T: Serialize>() {}
+fn assert_deserialize<T: serde::de::DeserializeOwned>() {}
+
+fn assert_change_is_serde<T: Comparable>() {
+	assert_serialize::<T::Desc>();
+	assert_serialize::<T::Change>();
+	assert_deserialize::<T::Desc>();
+	assert_deserialize::<T::Change>();
+}
+
+#[test]
+fn builtin_desc_and_change_are_serde() {
+	assert_change_is_serde::<i32>();
+	assert_change_is_serde::<bool>();
+	assert_change_is_serde::<char>();
+	assert_change_is_serde::<f64>();
+	assert_change_is_serde::<String>();
+	assert_change_is_serde::<Option<u32>>();
+	assert_change_is_serde::<Vec<u32>>();
+	assert_change_is_serde::<std::collections::BTreeSet<u32>>();
+	assert_change_is_serde::<std::collections::HashSet<u32>>();
+	assert_change_is_serde::<std::collections::BTreeMap<String, u32>>();
+	assert_change_is_serde::<std::collections::HashMap<String, u32>>();
+	assert_change_is_serde::<[u32; 4]>();
+	assert_change_is_serde::<(u32, String)>();
+	assert_change_is_serde::<(u8, u16, u32)>();
+	assert_change_is_serde::<Box<u32>>();
+	assert_change_is_serde::<std::path::PathBuf>();
+	// A generic projection: the bound holds for *any* `T: Comparable`.
+	assert_serialize::<<Vec<i32> as Comparable>::Change>();
+}
+
+// --- Problem 1: a `#[derive(Serialize)]` report holding `Change` values ------
+//
+// This is the reporter's struct, reduced to its essence.  It must *compile*.
+
+#[derive(Serialize)]
+struct DiffReport<T: Comparable> {
+	added: Vec<String>,
+	removed: Vec<String>,
+	modified: HashMap<String, <T as Comparable>::Change>,
+}
+
+#[test]
+fn diff_report_with_change_field_serializes() {
+	let mut modified = HashMap::new();
+	if let Changed::Changed(change) = 100i32.comparison(&200) {
+		modified.insert("answer".to_string(), change);
+	}
+	let report = DiffReport::<i32> { added: vec!["a".to_string()], removed: vec!["b".to_string()], modified };
+
+	let json = serde_json::to_value(&report).expect("DiffReport should serialize");
+	assert_eq!(json["added"], serde_json::json!(["a"]));
+	assert_eq!(json["removed"], serde_json::json!(["b"]));
+	// `I32Change(100, 200)` is a tuple struct → serializes as a two-element array.
+	assert_eq!(json["modified"]["answer"], serde_json::json!([100, 200]));
+}
+
+// --- Problem 2: deriving `Comparable` and `Serialize` on a generic type ------
+//
+// This is the reporter's `IdOrObject`, reduced to its essence.  Deriving
+// `Comparable` here used to fail with E0277 inside the derive macro.
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Comparable)]
+pub enum IdOrObject<T: Clone + PartialEq + Debug + Comparable> {
+	Id(#[comparable_ignore] u64),
+	Object(T),
+}
+
+#[test]
+fn generic_enum_change_round_trips() {
+	let a = IdOrObject::<i32>::Object(1);
+	let b = IdOrObject::<i32>::Object(2);
+
+	let change = match a.comparison(&b) {
+		Changed::Changed(c) => c,
+		Changed::Unchanged => panic!("expected a change"),
+	};
+
+	let json = serde_json::to_string(&change).expect("Change should serialize");
+	let back: <IdOrObject<i32> as Comparable>::Change = serde_json::from_str(&json).expect("Change should deserialize");
+	assert_eq!(change, back);
+}
+
+#[test]
+fn generic_enum_desc_round_trips() {
+	let value = IdOrObject::<i32>::Object(7);
+	let desc = value.describe();
+
+	let json = serde_json::to_string(&desc).expect("Desc should serialize");
+	let back: <IdOrObject<i32> as Comparable>::Desc = serde_json::from_str(&json).expect("Desc should deserialize");
+	assert_eq!(desc, back);
+}
+
+// A generic *struct* deriving both, for good measure.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Comparable)]
+pub struct Wrapper<T: Clone + PartialEq + Debug + Comparable> {
+	name: String,
+	payload: T,
+}
+
+#[test]
+fn generic_struct_change_round_trips() {
+	let a = Wrapper { name: "x".to_string(), payload: 1u32 };
+	let b = Wrapper { name: "y".to_string(), payload: 2u32 };
+
+	let change = match a.comparison(&b) {
+		Changed::Changed(c) => c,
+		Changed::Unchanged => panic!("expected a change"),
+	};
+
+	let json = serde_json::to_string(&change).expect("Change should serialize");
+	let back: <Wrapper<u32> as Comparable>::Change = serde_json::from_str(&json).expect("Change should deserialize");
+	assert_eq!(change, back);
+}

--- a/flake.nix
+++ b/flake.nix
@@ -92,6 +92,12 @@
             "cargo fmt --all -- --check";
           docs = mkPhaseCheck "docs" { RUSTDOCFLAGS = "-D warnings"; }
             "cargo doc --workspace --no-deps";
+          # The default `build`/test runs serde-disabled.  This check exercises
+          # the serde-enabled path (issue #12): the `Comparable` derive and the
+          # built-in impls must keep producing Serialize/Deserialize-able
+          # Desc/Change types, including through generic type parameters.
+          tests-serde = mkPhaseCheck "tests-serde" { }
+            "cargo test -p comparable_test --features serde --test serde";
         };
 
         formatter = pkgs.nixpkgs-fmt;

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -24,6 +24,9 @@ pre-commit:
     rust-test:
       glob: "*.rs"
       run: cargo test --workspace
+    rust-test-serde:
+      glob: "*.rs"
+      run: cargo test -p comparable_test --features serde --test serde
     rust-doc:
       glob: "*.rs"
       run: RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps


### PR DESCRIPTION
## Summary

Fixes #12 — with the `serde` feature enabled, `Comparable::Desc` and
`Comparable::Change` values could not be serialized through a generic
`T: Comparable`, and `#[derive(Comparable)]` on a generic type that also
derived `Serialize`/`Deserialize` failed to compile.

## Root cause

Every concrete `Desc`/`Change` type already derives `Serialize`/`Deserialize`
under the `serde` feature, but the `Comparable` trait only bounded its
associated types with `PartialEq + Debug`. So in a *generic* context the
compiler had no way to know `<T as Comparable>::Change` was serializable,
producing the two failures from the issue:

1. A `#[derive(Serialize)]` struct holding a `<T as Comparable>::Change`
   field (the reporter's `DiffReport`) — `E0277: Change: Serialize is not
   satisfied`.
2. `#[derive(Comparable)]` on a generic type — the generated `Desc`/`Change`
   derive serde, but serde infers `T: Serialize` while the field is actually
   `<T as Comparable>::Desc`, so it could not prove the bound (`E0277` inside
   the derive macro).

## Fix

- **`comparable` (lib).** Add a doc-hidden `MaybeSerde` marker —
  `Serialize + DeserializeOwned` with the feature on, an empty
  blanket-implemented marker with it off — and bound `Comparable::Desc` and
  `::Change` with it. The bound is vacuous when serde is off, and provable
  through any `T: Comparable` when it is on. Built-ins are adjusted to satisfy
  it: `HashMap`/`BTreeMap` require `Key: MaybeSerde`; `PathBufChange` derives
  serde like every other change type; and the generic array impl carries the
  bound as a `where`-clause premise (serde has no const-generic array impl, so
  `[_; N]: Serialize` is not provable for a generic `N` — it holds at every
  concrete `N` serde itself supports).

- **`comparable_derive`.** Emit `#[serde(bound = "T: comparable::Comparable")]`
  on generated generic types, replacing serde's spurious `T: Serialize`
  inference with the bound that actually discharges the associated-type
  fields.

- **`comparable_derive` (related).** While reproducing the issue I found that
  `#[derive(Comparable)]` on a **generic multi-field struct** never compiled
  at all (`Vec<FooChange>` in the generated `comparison` body dropped the
  `<T>` — `E0107`), which independently blocked serializing such a struct's
  changes. Threaded the generics through so the local is
  `Vec<FooChange<T>>`; non-generic output is unchanged.

## Tests

A new `serde`-gated `test/serde.rs` target (run via a `nix flake check`
entry, `make test-serde`, and lefthook) reproduces both halves of the issue
and round-trips generic enum/struct changes through JSON, plus compile-time
assertions that every built-in `Desc`/`Change` stays serde-serializable.
Generic-struct regression tests (exact change assertions) were added to the
existing generic-derive target so they also run in the default serde-off
build.

## Validation (local)

- `cargo test --workspace` (serde off) → 77 sample + 4 generic + 18 doctests, green
- `cargo test -p comparable_test --features serde --test serde` → 5 green
- `cargo clippy --workspace --all-targets -- -D warnings` and the same on the
  serde target → clean
- `cargo fmt --all --check` → clean
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps` → warning-free
- coverage gate → **92.27%** ≥ 90.215% baseline (rose)
- `nix flake check` evaluates with the new `tests-serde` check

🤖 Generated with [Claude Code](https://claude.com/claude-code)
